### PR TITLE
appendix 원문 레포의 최신 파일 내용으로 변경

### DIFF
--- a/second-edition/src/appendix-00.md
+++ b/second-edition/src/appendix-00.md
@@ -1,4 +1,4 @@
-# Appendix
+# 부록
 
-The following sections contain reference material you may find useful in your
-Rust journey.
+이번 장에는 러스트를 사용하는데 유용한 참고자료들이
+포함되어 있습니다.

--- a/second-edition/src/appendix-01-keywords.md
+++ b/second-edition/src/appendix-01-keywords.md
@@ -7,6 +7,8 @@ constants, macros, static values, attributes, types, traits, or lifetimes.
 
 ### Keywords Currently in Use
 
+The following keywords currently have the functionality described.
+
 * `as` - perform primitive casting, disambiguate the specific trait containing
   an item, or rename items in `use` and `extern crate` statements
 * `break` - exit a loop immediately

--- a/second-edition/src/appendix-02-operators.md
+++ b/second-edition/src/appendix-02-operators.md
@@ -6,189 +6,199 @@ trait bounds, macros, attributes, comments, tuples, and brackets.
 
 ### Operators
 
-The following list contains the operators in Rust, an example of how the
-operator would appear in context, a short explanation, and whether that
-operator is overloadable. If an operator is overloadable, the relevant trait to
-use to overload that operator is listed.
+Table B-1 contains the operators in Rust, an example of how the operator would
+appear in context, a short explanation, and whether that operator is
+overloadable. If an operator is overloadable, the relevant trait to use to
+overload that operator is listed.
 
+<span class="caption">Table B-1: Operators</span>
 
-* `!` (`ident!(...)`, `ident!{...}`, `ident![...]`): denotes macro
-expansion.
-* `!` (`!expr`): bitwise or logical complement. Overloadable (`Not`).
-* `!=` (`var != expr`): nonequality comparison. Overloadable (`PartialEq`).
-* `%` (`expr % expr`): arithmetic remainder. Overloadable (`Rem`).
-* `%=` (`var %= expr`): arithmetic remainder and assignment. Overloadable
-(`RemAssign`).
-* `&` (`&expr`, `&mut expr`): borrow.
-* `&` (`&type`, `&mut type`, `&'a type`, `&'a mut type`): borrowed pointer type.
-* `&` (`expr & expr`): bitwise AND. Overloadable (`BitAnd`).
-* `&=` (`var &= expr`): bitwise AND and assignment. Overloadable
-(`BitAndAssign`).
-* `&&` (`expr && expr`): logical AND.
-* `*` (`expr * expr`): arithmetic multiplication. Overloadable (`Mul`).
-* `*` (`*expr`): dereference.
-* `*` (`*const type`, `*mut type`): raw pointer.
-* `*=` (`var *= expr`): arithmetic multiplication and assignment. Overloadable
-(`MulAssign`).
-* `+` (`trait + trait`, `'a + trait`): compound type constraint.
-* `+` (`expr + expr`): arithmetic addition. Overloadable (`Add`).
-* `+=` (`var += expr`): arithmetic addition and assignment. Overloadable
-(`AddAssign`).
-* `,`: argument and element separator.
-* `-` (`- expr`): arithmetic negation. Overloadable (`Neg`).
-* `-` (`expr - expr`): arithmetic subtraction. Overloadable (`Sub`).
-* `-=` (`var -= expr`): arithmetic subtraction and assignment. Overloadable
-(`SubAssign`).
-* `->` (`fn(...) -> type`, `|...| -> type`): function and closure
-return type.
-* `.` (`expr.ident`): member access.
-* `..` (`..`, `expr..`, `..expr`, `expr..expr`): right-exclusive range literal.
-* `..` (`..expr`): struct literal update syntax.
-* `..` (`variant(x, ..)`, `struct_type { x, .. }`): “and the rest” pattern
-binding.
-* `...` (`expr...expr`) *in a pattern*: inclusive range pattern.
-* `/` (`expr / expr`): arithmetic division. Overloadable (`Div`).
-* `/=` (`var /= expr`): arithmetic division and assignment. Overloadable
-(`DivAssign`).
-* `:` (`pat: type`, `ident: type`): constraints.
-* `:` (`ident: expr`): struct field initializer.
-* `:` (`'a: loop {...}`): loop label.
-* `;`: statement and item terminator.
-* `;` (`[...; len]`): part of fixed-size array syntax
-* `<<` (`expr << expr`): left-shift. Overloadable (`Shl`).
-* `<<=` (`var <<= expr`): left-shift and assignment. Overloadable (`ShlAssign`).
-* `<` (`expr < expr`): less-than comparison. Overloadable (`PartialOrd`).
-* `<=` (`expr <= expr`): less-than or equal-to comparison. Overloadable
-(`PartialOrd`).
-* `=` (`var = expr`, `ident = type`): assignment/equivalence.
-* `==` (`expr == expr`): equality comparison. Overloadable (`PartialEq`).
-* `=>` (`pat => expr`): part of match arm syntax.
-* `>` (`expr > expr`): greater-than comparison. Overloadable (`PartialOrd`).
-* `>=` (`expr >= expr`): greater-than or equal-to comparison. Overloadable
-(`PartialOrd`).
-* `>>` (`expr >> expr`): right-shift. Overloadable (`Shr`).
-* `>>=` (`var >>= expr`): right-shift and assignment. Overloadable
-(`ShrAssign`).
-* `@` (`ident @ pat`): pattern binding.
-* `^` (`expr ^ expr`): bitwise exclusive OR. Overloadable (`BitXor`).
-* `^=` (`var ^= expr`): bitwise exclusive OR and assignment. Overloadable
-(`BitXorAssign`).
-* `|` (`pat | pat`): pattern alternatives.
-* `|` (`|…| expr`): closures.
-* `|` (`expr | expr`): bitwise OR. Overloadable (`BitOr`).
-* `|=` (`var |= expr`): bitwise OR and assignment. Overloadable (`BitOrAssign`).
-* `||` (`expr || expr`): logical OR.
-* `_`: “ignored” pattern binding. Also used to make integer literals readable.
-* `?` (`expr?`): error propagation.
+| Operator | Example | Explanation | Overloadable? |
+|----------|---------|-------------|---------------|
+| `!` | `ident!(...)`, `ident!{...}`, `ident![...]` | Macro expansion | |
+| `!` | `!expr` | Bitwise or logical complement | `Not` |
+| `!=` | `var != expr` | Nonequality comparison | `PartialEq` |
+| `%` | `expr % expr` | Arithmetic remainder | `Rem` |
+| `%=` | `var %= expr` | Arithmetic remainder and assignment | `RemAssign` |
+| `&` | `&expr`, `&mut expr` | Borrow | |
+| `&` | `&type`, `&mut type`, `&'a type`, `&'a mut type` | Borrowed pointer type | |
+| `&` | `expr & expr` | Bitwise AND | `BitAnd` |
+| `&=` | `var &= expr` | Bitwise AND and assignment | `BitAndAssign` |
+| `&&` | `expr && expr` | Logical AND | |
+| `*` | `expr * expr` | Arithmetic multiplication | `Mul` |
+| `*=` | `var *= expr` | Arithmetic multiplication and assignment | `MulAssign` |
+| `*` | `*expr` | Dereference | |
+| `*` | `*const type`, `*mut type` | Raw pointer | |
+| `+` | `trait + trait`, `'a + trait` | Compound type constraint | |
+| `+` | `expr + expr` | Arithmetic addition | `Add` |
+| `+=` | `var += expr` | Arithmetic addition and assignment | `AddAssign` |
+| `,` | `expr, expr` | Argument and element separator | |
+| `-` | `- expr` | Arithmetic negation | `Neg` |
+| `-` | `expr - expr` | Arithmetic subtraction | `Sub` |
+| `-=` | `var -= expr` | Arithmetic subtraction and assignment | `SubAssign` |
+| `->` | `fn(...) -> type`, <code>\|...\| -> type</code> | Function and closure return type | |
+| `.` | `expr.ident` | Member access | |
+| `..` | `..`, `expr..`, `..expr`, `expr..expr` | Right-exclusive range literal | |
+| `..` | `..expr` | Struct literal update syntax | |
+| `..` | `variant(x, ..)`, `struct_type { x, .. }` | “And the rest” pattern binding | |
+| `...` | `expr...expr` | In a pattern: inclusive range pattern | |
+| `/` | `expr / expr` | Arithmetic division | `Div` |
+| `/=` | `var /= expr` | Arithmetic division and assignment | `DivAssign` |
+| `:` | `pat: type`, `ident: type` | Constraints | |
+| `:` | `ident: expr` | Struct field initializer | |
+| `:` | `'a: loop {...}` | Loop label | |
+| `;` | `expr;` | Statement and item terminator | |
+| `;` | `[...; len]` | Part of fixed-size array syntax | |
+| `<<` | `expr << expr` | Left-shift | `Shl` |
+| `<<=` | `var <<= expr` | Left-shift and assignment | `ShlAssign` |
+| `<` | `expr < expr` | Less than comparison | `PartialOrd` |
+| `<=` | `expr <= expr` | Less than or equal to comparison | `PartialOrd` |
+| `=` | `var = expr`, `ident = type` | Assignment/equivalence | |
+| `==` | `expr == expr` | Equality comparison | `PartialEq` |
+| `=>` | `pat => expr` | Part of match arm syntax | |
+| `>` | `expr > expr` | Greater than comparison | `PartialOrd` |
+| `>=` | `expr >= expr` | Greater than or equal to comparison | `PartialOrd` |
+| `>>` | `expr >> expr` | Right-shift | `Shr` |
+| `>>=` | `var >>= expr` | Right-shift and assignment | `ShrAssign` |
+| `@` | `ident @ pat` | Pattern binding | |
+| `^` | `expr ^ expr` | Bitwise exclusive OR | `BitXor` |
+| `^=` | `var ^= expr` | Bitwise exclusive OR and assignment | `BitXorAssign` |
+| <code>\|</code> | <code>pat \| pat</code> | Pattern alternatives | |
+| <code>\|</code> | <code>expr \| expr</code> | Bitwise OR | `BitOr` |
+| <code>\|=</code> | <code>var \|= expr</code> | Bitwise OR and assignment | `BitOrAssign` |
+| <code>\|\|</code> | <code>expr \|\| expr</code> | Logical OR | |
+| `?` | `expr?` | Error propagation | |
 
 ### Non-operator Symbols
 
 The following list contains all non-letters that don’t function as operators;
 that is, they don’t behave like a function or method call.
 
-#### Stand-Alone Syntax
+Table B-2 shows symbols that appear on their own and are valid in a variety of
+locations.
 
-* `'ident`: named lifetime or loop label.
-* `...u8`, `...i32`, `...f64`, `...usize`, *etc.*: numeric literal of
-specific type.
-* `"..."`: string literal.
-* `r"..."`, `r#"..."#`, `r##"..."##`, *etc.*: raw string literal,
-escape characters are not processed.
-* `b"..."`: byte string literal, constructs a `[u8]` instead of a string.
-* `br"..."`, `br#"..."#`, `br##"..."##`, *etc.*: raw byte string
-literal, combination of raw and byte string literal.
-* `'...'`: character literal.
-* `b'...'`: ASCII byte literal.
-* `|...| expr`: closure.
-* `!`: always empty bottom type for diverging functions.
+<span class="caption">Table B-2: Stand-Alone Syntax</span>
 
-#### Path-Related Syntax
+| Symbol | Explanation |
+|--------|-------------|
+| `'ident` | Named lifetime or loop label |
+| `...u8`, `...i32`, `...f64`, `...usize`, etc. | Numeric literal of specific type |
+| `"..."` | String literal |
+| `r"..."`, `r#"..."#`, `r##"..."##`, etc. | Raw string literal, escape characters not processed |
+| `b"..."` | Byte string literal; constructs a `[u8]` instead of a string |
+| `br"..."`, `br#"..."#`, `br##"..."##`, etc. | Raw byte string literal, combination of raw and byte string literal |
+| `'...'` | Character literal |
+| `b'...'` | ASCII byte literal |
+| <code>\|...\| expr</code> | Closure |
+| `!` | Always empty bottom type for diverging functions |
+| `_` | “Ignored” pattern binding; also used to make integer literals readable |
 
-* `ident::ident`: namespace path.
-* `::path`: path relative to the crate root (*i.e.*, an explicitly absolute
-path).
-* `self::path`: path relative to the current module (*i.e.*, an explicitly
-relative path).
-* `super::path`: path relative to the parent of the current module.
-* `type::ident`, `<type as trait>::ident`: associated constants, functions, and
-types.
-* `<type>::...`: associated item for a type that cannot be directly named
-(*e.g.*, `<&T>::...`, `<[T]>::...`, *etc.*).
-* `trait::method(...)`: disambiguating a method call by naming the trait
-that defines it.
-* `type::method(...)`: disambiguating a method call by naming the type for
-which it’s defined.
-* `<type as trait>::method(...)`: disambiguating a method call by naming
-the trait *and* type.
+Table B-3 shows symbols that appear in the context of a path through the module
+hierarchy to an item.
 
-#### Generics
+<span class="caption">Table B-3: Path-Related Syntax</span>
 
-* `path<...>` (*e.g.*, `Vec<u8>`): specifies parameters to generic type *in
-a type*.
-* `path::<...>`, `method::<...>` (*e.g.*, `"42".parse::<i32>()`):
-specifies parameters to generic type, function, or method *in an expression*.
-Often referred to as *turbofish*.
-* `fn ident<...> ...`: define generic function.
-* `struct ident<...> ...`: define generic structure.
-* `enum ident<...> ...`: define generic enumeration.
-* `impl<...> ...`: define generic implementation.
-* `for<...> type`: higher-ranked lifetime bounds.
-* `type<ident=type>` (*e.g.*, `Iterator<Item=T>`): a generic type where one or
-more associated types have specific assignments.
+| Symbol | Explanation |
+|--------|-------------|
+| `ident::ident` | Namespace path |
+| `::path` | Path relative to the crate root (i.e., an explicitly absolute path) |
+| `self::path` | Path relative to the current module (i.e., an explicitly relative path).
+| `super::path` | Path relative to the parent of the current module |
+| `type::ident`, `<type as trait>::ident` | Associated constants, functions, and types |
+| `<type>::...` | Associated item for a type that cannot be directly named (e.g., `<&T>::...`, `<[T]>::...`, etc.) |
+| `trait::method(...)` | Disambiguating a method call by naming the trait that defines it |
+| `type::method(...)` | Disambiguating a method call by naming the type for which it’s defined |
+| `<type as trait>::method(...)` | Disambiguating a method call by naming the trait and type |
 
-#### Trait Bound Constraints
+Table B-4 shows symbols that appear in the context of using generic type
+parameters.
 
-* `T: U`: generic parameter `T` constrained to types that implement `U`.
-* `T: 'a`: generic type `T` must outlive lifetime `'a`. When we say that a type
-“outlives” the lifetime, we mean it cannot transitively contain any references
-with lifetimes shorter than `'a`.
-* `T : 'static`: the generic type `T` contains no borrowed references other
-than `'static` ones.
-* `'b: 'a`: generic lifetime `'b` must outlive lifetime `'a`.
-* `T: ?Sized`: allow generic type parameter to be a dynamically sized type.
-* `'a + trait`, `trait + trait`: compound type constraint.
+<span class="caption">Table B-4: Generics</span>
 
-#### Macros and Attributes
+| Symbol | Explanation |
+|--------|-------------|
+| `path<...>` | Specifies parameters to generic type in a type (e.g., `Vec<u8>`) |
+| `path::<...>`, `method::<...>` | Specifies parameters to generic type, function, or method in an expression; often referred to as turbofish (e.g., `"42".parse::<i32>()`) |
+| `fn ident<...> ...` | Define generic function |
+| `struct ident<...> ...` | Define generic structure |
+| `enum ident<...> ...` | Define generic enumeration |
+| `impl<...> ...` | Define generic implementation |
+| `for<...> type` | Higher-ranked lifetime bounds |
+| `type<ident=type>` | A generic type where one or more associated types have specific assignments (e.g., `Iterator<Item=T>`) |
 
-* `#[meta]`: outer attribute.
-* `#![meta]`: inner attribute.
-* `$ident`: macro substitution.
-* `$ident:kind`: macro capture.
-* `$(…)…`: macro repetition.
+Table B-5 shows symbols that appear in the context of constraining generic type
+parameters with trait bounds.
 
-#### Comments
+<span class="caption">Table B-5: Trait Bound Constraints</span>
 
-* `//`: line comment.
-* `//!`: inner line doc comment.
-* `///`: outer line doc comment.
-* `/*...*/`: block comment.
-* `/*!...*/`: inner block doc comment.
-* `/**...*/`: outer block doc comment.
+| Symbol | Explanation |
+|--------|-------------|
+| `T: U` | Generic parameter `T` constrained to types that implement `U` |
+| `T: 'a` | Generic type `T` must outlive lifetime `'a` (meaning the type cannot transitively contain any references with lifetimes shorter than `'a`) |
+| `T : 'static` | Generic type `T` contains no borrowed references other than `'static` ones |
+| `'b: 'a` | Generic lifetime `'b` must outlive lifetime `'a` |
+| `T: ?Sized` | Allow generic type parameter to be a dynamically sized type |
+| `'a + trait`, `trait + trait` | Compound type constraint |
 
-#### Tuples
+Table B-6 shows symbols that appear in the context of calling or defining
+macros and specifying attributes on an item.
 
-* `()`: empty tuple (*aka* unit), both literal and type.
-* `(expr)`: parenthesized expression.
-* `(expr,)`: single-element tuple expression.
-* `(type,)`: single-element tuple type.
-* `(expr, ...)`: tuple expression.
-* `(type, ...)`: tuple type.
-* `expr(expr, ...)`: function call expression. Also used to initialize
-tuple `struct`s and tuple `enum` variants.
-* `ident!(...)`, `ident!{...}`, `ident![...]`: macro invocation.
-* `expr.0`, `expr.1`, *etc.*: tuple indexing.
+<span class="caption">Table B-6: Macros and Attributes</span>
 
-#### Curly Brackets
+| Symbol | Explanation |
+|--------|-------------|
+| `#[meta]` | Outer attribute |
+| `#![meta]` | Inner attribute |
+| `$ident` | Macro substitution |
+| `$ident:kind` | Macro capture |
+| `$(…)…` | Macro repetition |
 
-* `{...}`: block expression.
-* `Type {...}`: `struct` literal.
+Table B-7 shows symbols that create comments.
 
-#### Square Brackets
+<span class="caption">Table B-7: Comments</span>
 
-* `[...]`: array literal.
-* `[expr; len]`: array literal containing `len` copies of `expr`.
-* `[type; len]`: array type containing `len` instances of `type`.
-* `expr[expr]`: collection indexing. Overloadable (`Index`, `IndexMut`).
-* `expr[..]`, `expr[a..]`, `expr[..b]`, `expr[a..b]`: collection indexing
-pretending to be collection slicing, using `Range`, `RangeFrom`, `RangeTo`, or
-`RangeFull` as the “index.”
+| Symbol | Explanation |
+|--------|-------------|
+| `//` | Line comment |
+| `//!` | Inner line doc comment |
+| `///` | Outer line doc comment |
+| `/*...*/` | Block comment |
+| `/*!...*/` | Inner block doc comment |
+| `/**...*/` | Outer block doc comment |
+
+Table B-8 shows symbols that appear in the context of using tuples.
+
+<span class="caption">Table B-8: Tuples</span>
+
+| Symbol | Explanation |
+|--------|-------------|
+| `()` | Empty tuple (aka unit), both literal and type |
+| `(expr)` | Parenthesized expression |
+| `(expr,)` | Single-element tuple expression |
+| `(type,)` | Single-element tuple type |
+| `(expr, ...)` | Tuple expression |
+| `(type, ...)` | Tuple type |
+| `expr(expr, ...)` | Function call expression; also used to initialize tuple `struct`s and tuple `enum` variants |
+| `ident!(...)`, `ident!{...}`, `ident![...]` | Macro invocation |
+| `expr.0`, `expr.1`, etc. | Tuple indexing |
+
+Table B-9 shows the contexts in which curly braces are used.
+
+<span class="caption">Table B-9: Curly Brackets</span>
+
+| Context | Explanation |
+|---------|-------------|
+| `{...}` | Block expression |
+| `Type {...}` | `struct` literal |
+
+Table B-10 shows the contexts in which square brackets are used.
+
+<span class="caption">Table B-10: Square Brackets</span>
+
+| Context | Explanation |
+|---------|-------------|
+| `[...]` | Array literal |
+| `[expr; len]` | Array literal containing `len` copies of `expr` |
+| `[type; len]` | Array type containing `len` instances of `type` |
+| `expr[expr]` | Collection indexing. Overloadable (`Index`, `IndexMut`) |
+| `expr[..]`, `expr[a..]`, `expr[..b]`, `expr[a..b]` | Collection indexing pretending to be collection slicing, using `Range`, `RangeFrom`, `RangeTo`, or `RangeFull` as the “index” |

--- a/second-edition/src/appendix-03-derivable-traits.md
+++ b/second-edition/src/appendix-03-derivable-traits.md
@@ -1,10 +1,10 @@
 ## Appendix C: Derivable Traits
 
-In various places in the book, we’ve discussed the `derive` attribute that you
-can apply to a struct or enum definition.
+In various places in the book, we’ve discussed the `derive` attribute, which
+you can apply to a struct or enum definition. The `derive` attribute generates
+code that will implement a trait with its own default implementation on the
+type you’ve annotated with the `derive` syntax.
 
-The `derive` attribute generates code that will implement a trait with its own
-default implementation on the type you’ve annotated with the `derive` syntax.
 In this appendix, we provide a reference of all the traits in the standard
 library that you can use with `derive`. Each section covers:
 
@@ -25,15 +25,15 @@ trying to accomplish.
 
 An example of a trait that can’t be derived is `Display`, which handles
 formatting for end users. You should always consider the appropriate way to
-display a type to an end user: for example, what parts of the type should an
-end user be allowed to see? What parts would they find relevant? What format of
-the data would be most relevant to them? The Rust compiler doesn’t have this
-insight, so it can’t provide appropriate default behavior for you.
+display a type to an end user. What parts of the type should an end user be
+allowed to see? What parts would they find relevant? What format of the data
+would be most relevant to them? The Rust compiler doesn’t have this insight, so
+it can’t provide appropriate default behavior for you.
 
 The list of derivable traits provided in this appendix is not comprehensive:
 libraries can implement `derive` for their own traits, making the list of
 traits you can use `derive` with truly open-ended. Implementing `derive`
-involves using a procedural macro, which is covered in Appendix D, “Macros.”
+involves using a procedural macro, which is covered in Appendix D.
 
 ### `Debug` for Programmer Output
 
@@ -54,9 +54,9 @@ The `PartialEq` trait allows you to compare instances of a type to check for
 equality and enables use of the `==` and `!=` operators.
 
 Deriving `PartialEq` implements the `eq` method. When `PartialEq` is derived on
-structs, two instances are equal only if *all* fields are equal and not equal
-if any fields are not equal. When derived on enums, each variant is equal to
-itself and not equal to the other variants.
+structs, two instances are equal only if *all* fields are equal, and the
+instances are not equal if any fields are not equal. When derived on enums,
+each variant is equal to itself and not equal to the other variants.
 
 The `PartialEq` trait is required, for example, with the use of the
 `assert_eq!` macro, which needs to be able to compare two instances of a type
@@ -69,8 +69,8 @@ implement `PartialEq` can implement `Eq`. One example of this is floating point
 number types: the implementation of floating point numbers states that two
 instances of the not-a-number (`NaN`) value are not equal to each other.
 
-An example of when `Eq` is required is for keys in a `HashMap` so the `HashMap`
-can tell whether two keys are the same.
+An example of when `Eq` is required is for keys in a `HashMap<K, V>` so the
+`HashMap<K, V>` can tell whether two keys are the same.
 
 ### `PartialOrd` and `Ord` for Ordering Comparisons
 
@@ -146,13 +146,13 @@ code might be slower or have to use `clone` in places.
 ### `Hash` for Mapping a Value to a Value of Fixed Size
 
 The `Hash` trait allows you to take an instance of a type of arbitrary size and
-map that instance to a value of fixed size, using a hash function. Deriving
+map that instance to a value of fixed size using a hash function. Deriving
 `Hash` implements the `hash` method. The derived implementation of the `hash`
 method combines the result of calling `hash` on each of the parts of the type,
 meaning all fields or values must also implement `Hash` to derive `Hash`.
 
-An example of when `Hash` is required is in storing keys in a `HashMap` to
-store data efficiently.
+An example of when `Hash` is required is in storing keys in a `HashMap<K, V>`
+to store data efficiently.
 
 ### `Default` for Default Values
 
@@ -168,7 +168,7 @@ Struct Update Syntax” section in Chapter 5. You can customize a few fields of 
 struct and then set and use a default value for the rest of the fields by using
 `..Default::default()`.
 
-The `Default` trait is required when, for example, you use the
-`unwrap_or_default` method on `Option<T>` instances. If the `Option<T>` is
-`None`, the `unwrap_or_default` method will return the result of
-`Default::default` for the type `T` stored in the `Option<T>`.
+The `Default` trait is required when you use the method `unwrap_or_default` on
+`Option<T>` instances, for example. If the `Option<T>` is `None`, the method
+`unwrap_or_default` will return the result of `Default::default` for the type
+`T` stored in the `Option<T>`.

--- a/second-edition/src/appendix-04-macros.md
+++ b/second-edition/src/appendix-04-macros.md
@@ -11,11 +11,11 @@ follows:
 We’re covering the details of macros in an appendix because they’re still
 evolving in Rust. Macros have changed and, in the near future, will change at a
 quicker rate than the rest of the language and standard library since Rust 1.0,
-so this section is more likely to date than the rest of the book. Due to Rust’s
-stability guarantees, the code shown here will continue to work with future
-versions. But there may be additional capabilities or easier ways to write
-macros that weren’t available at the time of this publication. Bear that in
-mind when you try to implement anything from this appendix.
+so this section is more likely to become out-of-date than the rest of the book.
+Due to Rust’s stability guarantees, the code shown here will continue to work
+with future versions, but there may be additional capabilities or easier ways
+to write macros that weren’t available at the time of this publication. Bear
+that in mind when you try to implement anything from this appendix.
 
 ### The Difference Between Macros and Functions
 
@@ -90,11 +90,11 @@ let v: Vec<u32> = vec![1, 2, 3];
 ```
 
 We could also use the `vec!` macro to make a vector of two integers or a vector
-of five string slices: we wouldn’t be able to use a function to do the same
+of five string slices. We wouldn’t be able to use a function to do the same
 because we wouldn’t know the number or type of values up front.
 
 Let’s look at a slightly simplified definition of the `vec!` macro in Listing
-D-1:
+D-1.
 
 ```rust
 #[macro_export]
@@ -309,12 +309,6 @@ To start defining the procedural macro, place the code in Listing D-3 into your
 *src/lib.rs* file for the `hello_macro_derive` crate. Note that this code won’t
 compile until we add a definition for the `impl_hello_macro` function.
 
-Notice the way we’ve split the functions in D-3; this will be the same for
-almost every procedural macro crate you see or create, because it makes writing
-a procedural macro more convenient. What you choose to do in the place where
-the `impl_hello_macro` function is called will be different depending on your
-procedural macro’s purpose.
-
 <span class="filename">Filename: hello_macro_derive/src/lib.rs</span>
 
 ```rust,ignore
@@ -343,6 +337,12 @@ pub fn hello_macro_derive(input: TokenStream) -> TokenStream {
 
 <span class="caption">Listing D-3: Code that most procedural macro crates will
 need to have for processing Rust code</span>
+
+Notice the way we’ve split the functions in D-3; this will be the same for
+almost every procedural macro crate you see or create, because it makes writing
+a procedural macro more convenient. What you choose to do in the place where
+the `impl_hello_macro` function is called will be different depending on your
+procedural macro’s purpose.
 
 We’ve introduced three new crates: `proc_macro`, [`syn`], and [`quote`]. The
 `proc_macro` crate comes with Rust, so we didn’t need to add that to the
@@ -403,7 +403,7 @@ where we’ll build the new Rust code we want to include. But before we do, note
 that the last part of this `hello_macro_derive` function uses the `parse`
 function from the `quote` crate to turn the output of the `impl_hello_macro`
 function back into a `TokenStream`. The returned `TokenStream` is added to the
-code that our crate users write, so when they compile their crate, they get
+code that our crate users write, so when they compile their crate, they’ll get
 extra functionality that we provide.
 
 You might have noticed that we’re calling `unwrap` to panic if the calls to the
@@ -439,7 +439,7 @@ annotated type using `ast.ident`. The code in Listing D-2 specifies that the
 
 The `quote!` macro lets us write the Rust code that we want to return and
 convert it into `quote::Tokens`. This macro also provides some very cool
-templating mechanics; we can write `#name` and `quote!` will replace it with
+templating mechanics; we can write `#name`, and `quote!` will replace it with
 the value in the variable named `name`. You can even do some repetition similar
 to the way regular macros work. Check out [the `quote` crate’s
 docs][quote-docs] for a thorough introduction.

--- a/second-edition/src/appendix-05-translation.md
+++ b/second-edition/src/appendix-05-translation.md
@@ -11,7 +11,7 @@ For resources in languages other than English. Most are still in progress; see
 - [简体中文](http://www.broadview.com.cn/article/144), [alternate](https://github.com/KaiserY/trpl-zh-cn)
 - [Українська](https://github.com/pavloslav/rust-book-uk-ua)
 - [Español](https://github.com/thecodix/book)
-- [Italiano](https://github.com/CodelessFuture/trpl2-it)
+- [Italiano](https://github.com/AgeOfWar/rust-book-it)
 - [Русский](https://github.com/iDeBugger/rust-book-ru)
 - [한국어](https://github.com/rinthel/rust-lang-book-ko)
 - [日本語](https://github.com/hazama-yuinyan/book)

--- a/second-edition/src/appendix-07-nightly-rust.md
+++ b/second-edition/src/appendix-07-nightly-rust.md
@@ -150,7 +150,7 @@ $ rustup install nightly
 
 You can see all of the *toolchains* (releases of Rust and associated
 components) you have installed with `rustup` as well. Here’s an example on one
-of your authors’ computers:
+of your authors’ Windows computer:
 
 ```powershell
 > rustup toolchain list


### PR DESCRIPTION

죄송스럽게도 아직 거의 작업을 못했습니다만 (1줄 짜리 커밋이 껴있긴 하네요), 원문 레포의 파일(second-edition)과 다른 부분이 꽤 있는걸 발견해서 임의로 최신 파일 내용으로 변경해 보았습니다.

제가 어떤식으로 원문 파일을 업데이트 하는지 정확히 모르다 보니 충돌이 생기지 않을까 걱정이 되는데,
따로 문제가 되지 않는다면 혹시 모를 부록을 보시거나 번역하시는 분을 위해 먼저 업데이트를 하는 게 좋을 것 같습니다.

문제가 된다면 기존 파일대로 번역을 진행하거나, 최신 내용으로 변경 해둔 상태에서 번역을 하되 완료한 상태에서 다시 PR 을 넣는 식으로 하겠습니다.