### PR TITLE
표현식 오타수정

### DIFF
--- a/second-edition/src/ch04-01-what-is-ownership.md
+++ b/second-edition/src/ch04-01-what-is-ownership.md
@@ -490,7 +490,7 @@ fn main() {
 }
 
 fn calculate_length(s: String) -> (String, usize) {
-    let length = s.len(); // len() returns the length of a String.
+    let length = s.len(); // len()함수는 문자열의 길이를 반환합니다.
 
     (s, length)
 }

--- a/second-edition/src/ch04-03-slices.md
+++ b/second-edition/src/ch04-03-slices.md
@@ -286,7 +286,7 @@ let s = "Hello, world!";
 fn first_word(s: &String) -> &str {
 ```
 
-더 경험이 많은 러스트인이라면 대신 아래와 같이 작성하는데, 그 이유는 `String`과 `&str` 둘 모두에
+더 경험이 많은 러스트인이라면 대신 아래와 같이 작성하는데, 그 이유는 `&String`과 `&str` 둘 모두에
 대한 같은 함수를 사용할 수 있도록 해주기 때문입니다.
 
 ```rust,ignore


### PR DESCRIPTION
second-edition의 ch04-03.
영어판 도큐먼트 내용에 따라 String을 &String으로 수정하였습니다.

<영어 도큐먼트 내용>
https://doc.rust-lang.org/book/ch04-03-slices.html
A more experienced Rustacean would write the signature shown in Listing 4-9 instead because it allows us to use the same function on both &String values and &str values.